### PR TITLE
Update FAQ address to current Sacramento location

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -29,7 +29,7 @@ const FAQ: React.FC = () => {
     {
       id: 4,
       question: "How can I contact Dinelogy customer service?",
-      answer: "To contact Dinelogy's customer service team, you can reach us through the following methods: Email us at info@dinelogy.com for general inquiries and support@dinelogy.com for technical support. You can also contact us through our website's contact form or visit our office at 123 Tech Street, Suite 100, San Francisco, CA 94102."
+      answer: "To contact Dinelogy's customer service team, you can reach us through the following methods: Email us at info@dinelogy.com for general inquiries and support@dinelogy.com for technical support. You can also contact us through our website's contact form or visit our office at 2108 N ST STE N, Sacramento, CA 95816, USA."
     },
     {
       id: 5,


### PR DESCRIPTION
## Summary
- Updated the address in the FAQ page from the old San Francisco location to the current Sacramento office address
- Changed from "123 Tech Street, Suite 100, San Francisco, CA 94102" to "2108 N ST STE N, Sacramento, CA 95816, USA"
- This ensures consistency across all pages (Footer, Contact, Privacy, Terms, and now FAQ)

## Test plan
- [x] Verify the FAQ page displays the correct address
- [x] Confirm address matches the format used in other pages
- [x] Check that no other outdated addresses remain in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Documentation:
- Replace the outdated San Francisco address with the Sacramento office address in the FAQ page